### PR TITLE
CI: build a Tcl 8.6-linked macOS arm64 binary

### DIFF
--- a/.github/workflows/mac-os-arm_build.yml
+++ b/.github/workflows/mac-os-arm_build.yml
@@ -9,12 +9,38 @@ on:
 
 jobs:
   release:
+    name: Build (macOS arm64 / Tcl 8.6)
     runs-on: macos-14
 
     steps:
       - name: check out git repository
         uses: actions/checkout@v4
-        
+
+      - name: build
+        run: |
+          brew install tcl-tk@8
+          TCLTK_PREFIX="$(brew --prefix tcl-tk@8)"
+          export PATH="$TCLTK_PREFIX/bin:$PATH"
+          export LDFLAGS="-L$TCLTK_PREFIX/lib"
+          export CPPFLAGS="-I$TCLTK_PREFIX/include"
+          export PKG_CONFIG_PATH="$TCLTK_PREFIX/lib/pkgconfig"
+          tclsh tcl-conf-arm
+          make install arch=arm64
+
+      - name: upload
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: macos-arm64
+          path: cmake/runtime/lib/tkdnd2.10.1
+
+  release-tcl9:
+    name: Build (macOS arm64 / Tcl 9)
+    runs-on: macos-14
+
+    steps:
+      - name: check out git repository
+        uses: actions/checkout@v4
+
       - name: build
         run: |
           brew reinstall tcl-tk
@@ -24,9 +50,9 @@ jobs:
           export PKG_CONFIG_PATH="/usr/local/opt/tcl-tk/lib/pkgconfig"
           tclsh tcl-conf-arm
           make install arch=arm64
-          
+
       - name: upload
         uses: actions/upload-artifact@v4.3.5
         with:
-          name: macos-arm64
+          name: macos-arm64-tcl9
           path: cmake/runtime/lib/tkdnd2.10.1


### PR DESCRIPTION
## Summary
- `mac-os-arm_build.yml`'s `brew reinstall tcl-tk` now pulls Homebrew's `tcl-tk` formula, which defaults to Tcl/Tk 9 — so the `macos-arm64` artifact was silently Tcl 9-only (`libtcl9tkdnd*.dylib`), even though most Python installs on macOS still bundle Tcl/Tk 8.6.
- Split the workflow into two jobs, mirroring the existing `windows-builds.yml` pattern: `macos-arm64` now builds against the versioned `tcl-tk@8` keg (real Tcl 8.6, confirmed via `_Tcl_InitStubs` symbol and no `tcl9` filename prefix), and `macos-arm64-tcl9` keeps the prior Tcl 9 behavior under its own artifact name.

## Test plan
- [x] Manually triggered the workflow via `workflow_dispatch` on this branch — both jobs succeeded.
- [x] Downloaded `macos-arm64` artifact and confirmed `libtkdnd2.10.1.dylib` (no `tcl9` prefix) exports `_Tcl_InitStubs`.
- [x] Downloaded `macos-arm64-tcl9` artifact and confirmed it's unaffected (`libtcl9tkdnd2.10.1.dylib`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)